### PR TITLE
Support ClangFormat v7.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Thus UniversalIndentGUI is open for nearly any new indenter and programming lang
 
 *   [Artistic Styler](http://astyle.sourceforge.net/)
 *   [BCPP](http://invisible-island.net/bcpp/)
+*   [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html)
 *   [Cobol Beautify](http://www.siber.com/sct/tools/cbl-beau.html)
 *   [CSSTidy](http://csstidy.sourceforge.net/)
 *   [Fortran 90 PPR](ftp://ftp.ifremer.fr/ifremer/ditigo/fortran90/)
@@ -140,7 +141,7 @@ But if you'd like to build UiGUI from source, follow these steps:
 5.  Run "make release".
 6.  Install it
         **Indenter binary packages** can be downloaded from the project at SourceForge
-        [here](http://sourceforge.net/project/showfiles.php?group_id=167482&package_id=293094).
+        [here](http://sourceforge.net/project/showfiles.php?group_id=167482&package_id=293094). **ClangFormat** is not part of them (yet), and you can download it separately at [the LLVM Builds page](http://llvm.org/builds/). (Rename it to `clang-format.exe` after downloading if needed.)
 
 Beneath the possibility to build UiGUI using qmake, also project files for Visual Studio 2005
         and XCode are included.

--- a/README_older_but_worth_reading.txt
+++ b/README_older_but_worth_reading.txt
@@ -17,6 +17,7 @@ One of the main features and the reason why this tool was (better is being) deve
 - Supports the following indenters:
   * Artistic Styler
   * BCPP
+  * ClangFormat
   * Cobol Beautifier
   * CSS Tidy
   * GNU Indent

--- a/buildRelease.sh
+++ b/buildRelease.sh
@@ -348,7 +348,7 @@ echo ""
 echo "Copying the indenter executable files to the target indenters dir"
 echo "-----------------------------------------------------------------"
 # This list does not include script based indenters. These are copied somewhere below.
-indenters="astyle$ext astyle.html uncrustify$ext uncrustify.txt xmlindent$ext xmlindent.txt"
+indenters="astyle$ext astyle.html clang-format$ext uncrustify$ext uncrustify.txt xmlindent$ext xmlindent.txt"
 # For win32 and Linux add some indenters that do not run or exist under MaxOSX
 if [ "$targetSystem" = "win32" ] || [ "$targetSystem" = "linux" ]; then
     indenters="$indenters bcpp$ext bcpp.txt csstidy$ext f90ppr.exe f90ppr.txt greatcode.exe greatcode.txt htb.exe htb.html indent$ext indent.html phpCB.html phpCB.exe psti_license.txt psti_manual.html psti.exe tidy$ext tidy.html vbsbeaut_keywords_indent.txt vbsbeaut_keywords.txt vbsbeaut.bat vbsbeaut.exe"

--- a/buildwin32release_gcc.bat
+++ b/buildwin32release_gcc.bat
@@ -55,7 +55,7 @@ echo.
 
 echo Copying the indenter executables and example file to the release indenters dir
 echo ------------------------------------------------------------------------------
-FOR %%A IN ( astyle.exe, astyle.html, bcpp.exe, bcpp.txt, csstidy.exe, gc.exe, gc.txt, indent.exe, libiconv-2.dll, libintl-2.dll, indent.html, JsDecoder.js, perltidy, PerlTidyLib.pm, phpStylist.php, phpStylist.txt, rbeautify.rb, ruby_formatter.rb, shellindent.awk, tidy.exe, tidy.html, uncrustify.exe, uncrustify.txt, xmlindent.exe, xmlindent.txt ) DO (
+FOR %%A IN ( astyle.exe, astyle.html, bcpp.exe, bcpp.txt, clang-format.exe csstidy.exe, gc.exe, gc.txt, indent.exe, libiconv-2.dll, libintl-2.dll, indent.html, JsDecoder.js, perltidy, PerlTidyLib.pm, phpStylist.php, phpStylist.txt, rbeautify.rb, ruby_formatter.rb, shellindent.awk, tidy.exe, tidy.html, uncrustify.exe, uncrustify.txt, xmlindent.exe, xmlindent.txt ) DO (
     if not exist .\indenters\%%A (
         echo WARNING!! File .\indenters\%%A not found!
 		set warningsoccurred=true

--- a/indenters/uigui_clangformat.ini
+++ b/indenters/uigui_clangformat.ini
@@ -1,0 +1,900 @@
+[header]
+categories="Overall Policy|Breaking and Joining|Brace Positioning|Indentation|Alignment|Horizontal Spacing|Vertical Spacing|Other Edits"
+cfgFileParameterEnding=cr
+configFilename=.clang-format
+fileTypes=*.cpp|*.cxx|*.C|*.c|*.h|*.hpp|*.java|*.js|*.m|*.mm|*.M|*.proto
+indenterFileName=clang-format
+indenterName=ClangFormat (C, C++, Java, JavaScript, ObjC, ObjC++, ProtoBuf)
+inputFileName=indentinput
+inputFileParameter="-style=file -i "
+manual=http://releases.llvm.org/7.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+outputFileName=indentinput
+outputFileParameter=none
+parameterOrder=pio
+stringparaminquotes=false
+showHelpParameter=-help
+useCfgFileParameter=none
+version=7.0.0
+
+[Language]
+Category=0
+Description="<html>(Language) Language this format style is targeted at.</html>"
+EditorType=multiple
+Enabled=true
+Choices="Language: Cpp|Language: Java|Language: JavaScript|Language: ObjC|Language: Proto|Language: TextProto|Language: TableGen"
+ChoicesReadable="(Cpp) C, C++|(Java) Java|(JavaScript) JavaScript|(ObjC) Objective C, Objective C++|(Proto) Protocol Buffers|(TextProto) Protocol Buffer messages in text format|(TableGen) TableGen"
+ValueDefault=0
+
+[BasedOnStyle]
+Category=0
+Description="<html>(BasedOnStyle) The style used for all options not specifically set in the configuration.</html>"
+EditorType=multiple
+Enabled=false
+Choices="BasedOnStyle: LLVM|BasedOnStyle: Google|BasedOnStyle: Chromium|BasedOnStyle: Mozilla|BasedOnStyle: WebKit"
+ChoicesReadable="(LLVM) LLVM coding standards - http://llvm.org/docs/CodingStandards.html|(Google) Google’s C++ style guide - https://google.github.io/styleguide/cppguide.html|(Chromium) Chromium’s style guide - http://www.chromium.org/developers/coding-style|(Mozilla) Mozilla’s style guide - https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Coding_Style|(WebKit) WebKit’s style guide - http://www.webkit.org/coding/coding-style.html"
+ValueDefault=0
+
+[AccessModifierOffset]
+Category=4
+Description="<html>The extra indent or outdent of access modifiers, e.g. <code>public:</code>.</html>"
+EditorType=numeric
+Enabled=false
+CallName="AccessModifierOffset: "
+MaxVal=100
+MinVal=-100
+Value=-2
+ValueDefault=-2
+
+[AlignAfterOpenBracket]
+Category=4
+Description="<html>(AlignAfterOpenBracket) Horizontally aligns arguments after an open bracket.<p>This applies to round brackets (parentheses), angle brackets and square brackets.</html>"
+EditorType=multiple
+Enabled=false
+Choices="AlignAfterOpenBracket: Align|AlignAfterOpenBracket: DontAlign|AlignAfterOpenBracket: AlwaysBreak"
+ChoicesReadable="(Align) Align parameters on the open bracket.|(DontAlign) Don’t align, instead use ContinuationIndentWidth.|(AlwaysBreak) Always break after an open bracket if the parameters don’t fit on a single line."
+ValueDefault=0
+
+[AlignConsecutiveAssignments]
+Category=4
+Description="<html>Aligns consecutive assignments.<p>This will align the assignment operators of consecutive lines. This will result in formattings like<pre>int aaaa = 12;<br/>int b    = 23;<br/>int ccc  = 23;</pre></html>"
+EditorType=boolean
+TrueFalse="AlignConsecutiveAssignments: true|AlignConsecutiveAssignments: false"
+Value=0
+ValueDefault=0
+
+[AlignConsecutiveDeclarations]
+Category=4
+Description="<html>Aligns consecutive declarations.<p>This will align the declaration names of consecutive lines. This will result in formattings like<pre>int         aaaa = 12;<br/>float       b = 23;<br/>std::string ccc = 23;</pre></html>"
+EditorType=boolean
+TrueFalse="AlignConsecutiveDeclarations: true|AlignConsecutiveDeclarations: false"
+Value=0
+ValueDefault=0
+
+[AlignEscapedNewlines]
+Category=4
+Description="<html>(AlignEscapedNewlines) Options for aligning backslashes in escaped newlines.</html>"
+EditorType=multiple
+Enabled=false
+Choices="AlignEscapedNewlines: DontAlign|AlignEscapedNewlines: Left|AlignEscapedNewlines: Right"
+ChoicesReadable="(DontAlign) Don’t align escaped newlines.|(Left) Align escaped newlines as far left as possible.|(Right) Align escaped newlines in the right-most column."
+ValueDefault=2
+
+[AlignOperands]
+Category=4
+Description="<html>Horizontally align operands of binary and ternary expressions.<p>Specifically, this aligns operands of a single expression that needs to be split over multiple lines, e.g.:<pre>int aaa = bbbbbbbbbbbbbbb +<br/>          ccccccccccccccc;</pre></html>"
+EditorType=boolean
+TrueFalse="AlignOperands: true|AlignOperands: false"
+Value=1
+ValueDefault=1
+
+[AlignTrailingComments]
+Category=4
+Description="<html>Aligns trailing comments.<pre>true:                                   false:<br/>int a;     // My comment a      vs.     int a; // My comment a<br/>int b = 2; // comment  b                int b = 2; // comment about b</pre></html>"
+EditorType=boolean
+TrueFalse="AlignTrailingComments: true|AlignTrailingComments: false"
+Value=1
+ValueDefault=1
+
+[AllowAllParametersOfDeclarationOnNextLine]
+Category=1
+Description="<html>If the function declaration doesn’t fit on a line, allow putting all parameters of a function declaration onto the next line even if <code>BinPackParameters</code> is <code>false</code>.<pre>true:<br/>void myFunction(<br/>    int a, int b, int c, int d, int e);<br/><br/>false:<br/>void myFunction(int a,<br/>                int b,<br/>                int c,<br/>                int d,<br/>                int e);</pre></html>"
+EditorType=boolean
+TrueFalse="AllowAllParametersOfDeclarationOnNextLine: true|AllowAllParametersOfDeclarationOnNextLine: false"
+Value=1
+ValueDefault=1
+
+[AllowShortBlocksOnASingleLine]
+Category=1
+Description="<html>Allows contracting simple braced statements to a single line.<p>E.g., this allows <code>if (a) { return; }</code> to be put on a single line (if <code>AllowShortIfStatementsOnASingleLine</code> is also enabled).</html>"
+EditorType=boolean
+TrueFalse="AllowShortBlocksOnASingleLine: true|AllowShortBlocksOnASingleLine: false"
+Value=0
+ValueDefault=0
+
+[AllowShortCaseLabelsOnASingleLine]
+Category=1
+Description="<html>Contracts short case labels to a single line.<pre>true:                                   false:<br/>switch (a) {                    vs.     switch (a) {<br/>case 1: x = 1; break;                   case 1:<br/>case 2: return;                           x = 1;<br/>}                                         break;<br/>                                        case 2:<br/>                                          return;<br/>                                        }</pre></html>"
+EditorType=boolean
+TrueFalse="AllowShortCaseLabelsOnASingleLine: true|AllowShortCaseLabelsOnASingleLine: false"
+Value=0
+ValueDefault=0
+
+[AllowShortFunctionsOnASingleLine]
+Category=1
+Description="<html>(AllowShortFunctionsOnASingleLine) <code>int f() { return 0; }</code> can be put on a single line.</html>"
+EditorType=multiple
+Enabled=false
+Choices="AllowShortFunctionsOnASingleLine: None|AllowShortFunctionsOnASingleLine: InlineOnly|AllowShortFunctionsOnASingleLine: Empty|AllowShortFunctionsOnASingleLine: Inline|AllowShortFunctionsOnASingleLine: All"
+ChoicesReadable="(None) Never merge functions into a single line.|(InlineOnly) Only merge functions defined inside a class.|(Empty) Only merge empty functions.|(Inline) Only merge functions defined inside a class. Implies “empty”.|(All) Merge all functions fitting on a single line."
+ValueDefault=4
+
+[AllowShortIfStatementsOnASingleLine]
+Category=1
+Description="<html><code>if (a) return;</code> can be put on a single line.<p>Note: If the statement body is a block then <code>AllowShortBlocksOnASingleLine</code> is also needed.</html>"
+EditorType=boolean
+TrueFalse="AllowShortIfStatementsOnASingleLine: true|AllowShortIfStatementsOnASingleLine: false"
+Value=0
+ValueDefault=0
+
+[AllowShortLoopsOnASingleLine]
+Category=1
+Description="<html><code>while (true) continue;</code> can be put on a single line.<p>Note: To put <code>do { true; } while(0);</code> on a single line, <code>AllowShortBlocksOnASingleLine</code> is also needed.</html>"
+EditorType=boolean
+TrueFalse="AllowShortLoopsOnASingleLine: true|AllowShortLoopsOnASingleLine: false"
+Value=0
+ValueDefault=0
+
+[AlwaysBreakAfterReturnType]
+Category=1
+Description="<html>(AlwaysBreakAfterReturnType) The function return type breaking style to use.</html>"
+EditorType=multiple
+Enabled=false
+Choices="AlwaysBreakAfterReturnType: None|AlwaysBreakAfterReturnType: All|AlwaysBreakAfterReturnType: TopLevel|AlwaysBreakAfterReturnType: AllDefinitions|AlwaysBreakAfterReturnType: TopLevelDefinitions"
+ChoicesReadable="(None) Break after return type automatically according to PenaltyReturnTypeOnItsOwnLine.|(All) Always break after the return type.|(TopLevel) Always break after the return types of top-level functions.|(AllDefinitions) Always break after the return type of function definitions.|(TopLevelDefinitions) Always break after the return type of top-level definitions."
+ValueDefault=0
+
+[AlwaysBreakBeforeMultilineStrings]
+Category=1
+Description="<html>Always break before multiline string literals.<p>This flag is meant to make cases where there are multiple multiline strings in a file look more consistent. Thus, it will only take effect if wrapping the string at that point leads to it being indented <code>ContinuationIndentWidth</code> spaces from the start of the line.</p><pre>true:                                  false:<br/>aaaa =                         vs.     aaaa = &quot;bbbb&quot;<br/>    &quot;bbbb&quot;                                    &quot;cccc&quot;;<br/>    &quot;cccc&quot;;</pre></html>"
+EditorType=boolean
+TrueFalse="AlwaysBreakBeforeMultilineStrings: true|AlwaysBreakBeforeMultilineStrings: false"
+Value=0
+ValueDefault=0
+
+[AlwaysBreakTemplateDeclarations]
+Category=1
+Description="<html>(AlwaysBreakTemplateDeclarations) The template declaration breaking style to use.</html>"
+EditorType=multiple
+Enabled=false
+Choices="AlwaysBreakTemplateDeclarations: No|AlwaysBreakTemplateDeclarations: MultiLine|AlwaysBreakTemplateDeclarations: Yes"
+ChoicesReadable="(No) Do not force break before declaration. PenaltyBreakTemplateDeclaration is taken into account.|(MultiLine) Force break after template declaration only when the following declaration spans multiple lines.|(Yes) Always break after template declaration."
+ValueDefault=0
+
+[BinPackArguments]
+Category=1
+Description="<html>If <code>false</code>, a function call’s arguments will either be all on the same line or will have one line each.<pre>true:<br/>void f() {<br/>  f(aaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaa,<br/>    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa);<br/>}<br/><br/>false:<br/>void f() {<br/>  f(aaaaaaaaaaaaaaaaaaaa,<br/>    aaaaaaaaaaaaaaaaaaaa,<br/>    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa);<br/>}</pre></html>"
+EditorType=boolean
+TrueFalse="BinPackArguments: true|BinPackArguments: false"
+Value=1
+ValueDefault=1
+
+[BinPackParameters]
+Category=1
+Description="<html>If <code>false</code>, a function declaration’s or function definition’s parameters will either all be on the same line or will have one line each.<pre>true:<br/>void f(int aaaaaaaaaaaaaaaaaaaa, int aaaaaaaaaaaaaaaaaaaa,<br/>       int aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) {}<br/><br/>false:<br/>void f(int aaaaaaaaaaaaaaaaaaaa,<br/>       int aaaaaaaaaaaaaaaaaaaa,<br/>       int aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) {}</pre></html>"
+EditorType=boolean
+TrueFalse="BinPackParameters: true|BinPackParameters: false"
+Value=1
+ValueDefault=1
+
+[BreakBeforeBraces]
+Category=2
+Description="<html>(BreakBeforeBraces) The brace breaking style to use.</html>"
+EditorType=multiple
+Enabled=false
+Choices="BreakBeforeBraces: Attach|BreakBeforeBraces: Linux|BreakBeforeBraces: Mozilla|BreakBeforeBraces: Stroustrup|BreakBeforeBraces: Allman|BreakBeforeBraces: GNU|BreakBeforeBraces: WebKit|BreakBeforeBraces: Custom"
+ChoicesReadable="(Attach) Always attach braces to surrounding context.|(Linux) Like Attach, but break before braces on function, namespace and class definitions.|(Mozilla) Like Attach, but break before braces on enum, function, and record definitions.|(Stroustrup) Like Attach, but break before function definitions, catch, and else.|(Allman) Always break before braces.|(GNU) Always break before braces and add an extra level of indentation to braces of control statements, not to those of class, function or other definitions.|(WebKit) Like Attach, but break before functions.|(Custom) Configure each individual brace in BraceWrapping."
+ValueDefault=0
+
+[BraceWrapping]
+Category=2
+Description="<html>Control of individual brace wrapping cases.<p>If <code>BreakBeforeBraces</code> is set to <code>Custom</code>, use the following options to specify how each individual brace case should be handled. Otherwise, this is ignored.</html>"
+EditorType=boolean
+TrueFalse="BraceWrapping:|BraceWrapping:"
+Value=1
+ValueDefault=1
+
+[ - AfterClass]
+Category=2
+Description="<html>Wrap <code>class</code> definitions.<pre>true:<br/>class foo {};<br/><br/>false:<br/>class foo<br/>{};</pre></html>"
+EditorType=boolean
+TrueFalse="    AfterClass: true|    AfterClass: false"
+Value=0
+ValueDefault=0
+
+[ - AfterControlStatement]
+Category=2
+Description="<html>Wrap control statements (<code>if</code>/<code>for</code>/<code>while</code>/<code>switch</code>/..).<pre>true:<br/>if (foo())<br/>{<br/>} else<br/>{}<br/>for (int i = 0; i &lt; 10; ++i)<br/>{}<br/><br/>false:<br/>if (foo()) {<br/>} else {<br/>}<br/>for (int i = 0; i &lt; 10; ++i) {<br/>}</pre></html>"
+EditorType=boolean
+TrueFalse="    AfterControlStatement: true|    AfterControlStatement: false"
+Value=0
+ValueDefault=0
+
+[ - AfterEnum]
+Category=2
+Description="<html>Wrap <code>enum</code> definitions.<pre>true:<br/>enum X : int<br/>{<br/>  B<br/>};<br/><br/>false:<br/>enum X : int { B };</pre></html>"
+EditorType=boolean
+TrueFalse="    AfterEnum: true|    AfterEnum: false"
+Value=0
+ValueDefault=0
+
+[ - AfterFunction]
+Category=2
+Description="<html>Wrap function definitions.<pre>true:<br/>void foo()<br/>{<br/>  bar();<br/>  bar2();<br/>}<br/><br/>false:<br/>void foo() {<br/>  bar();<br/>  bar2();<br/>}</pre></html>"
+EditorType=boolean
+TrueFalse="    AfterFunction: true|    AfterFunction: false"
+Value=0
+ValueDefault=0
+
+[ - AfterNamespace]
+Category=2
+Description="<html>Wrap <code>namespace</code> definitions.<pre>true:<br/>namespace<br/>{<br/>int foo();<br/>int bar();<br/>}<br/><br/>false:<br/>namespace {<br/>int foo();<br/>int bar();<br/>}</pre></html>"
+EditorType=boolean
+TrueFalse="    AfterNamespace: true|    AfterNamespace: false"
+Value=0
+ValueDefault=0
+
+[ - AfterObjCDeclaration]
+Category=2
+Description="<html>Wrap ObjC definitions (interfaces, implementations…). <code>@autoreleasepool</code> and <code>@synchronized</code> blocks are wrapped according to <code>AfterControlStatement</code> flag.</html>"
+EditorType=boolean
+TrueFalse="    AfterObjCDeclaration: true|    AfterObjCDeclaration: false"
+Value=0
+ValueDefault=0
+
+[ - AfterStruct]
+Category=2
+Description="<html>Wrap <code>struct</code> definitions.<pre>true:<br/>struct foo<br/>{<br/>  int x;<br/>};<br/><br/>false:<br/>struct foo {<br/>  int x;<br/>};</pre></html>"
+EditorType=boolean
+TrueFalse="    AfterStruct: true|    AfterStruct: false"
+Value=0
+ValueDefault=0
+
+[ - AfterUnion]
+Category=2
+Description="<html>Wrap <code>union</code> definitions.<pre>true:<br/>union foo<br/>{<br/>  int x;<br/>}<br/><br/>false:<br/>union foo {<br/>  int x;<br/>}</pre></html>"
+EditorType=boolean
+TrueFalse="    AfterUnion: true|    AfterUnion: false"
+Value=0
+ValueDefault=0
+
+[ - AfterExternBlock]
+Category=2
+Description="<html>Wrap <code>extern</code> blocks.<pre>true:<br/>extern &quot;C&quot;<br/>{<br/>  int foo();<br/>}<br/><br/>false:<br/>extern &quot;C&quot; {<br/>int foo();<br/>}</pre></html>"
+EditorType=boolean
+TrueFalse="    AfterExternBlock: true|    AfterExternBlock: false"
+Value=0
+ValueDefault=0
+
+[ - BeforeCatch]
+Category=2
+Description="<html>Wrap before <code>catch</code>.<pre>true:<br/>try {<br/>  foo();<br/>}<br/>catch () {<br/>}<br/><br/>false:<br/>try {<br/>  foo();<br/>} catch () {<br/>}</pre></html>"
+EditorType=boolean
+TrueFalse="    BeforeCatch: true|    BeforeCatch: false"
+Value=0
+ValueDefault=0
+
+[ - BeforeElse]
+Category=2
+Description="<html>Wrap before <code>else</code>.<pre>true:<br/>if (foo()) {<br/>}<br/>else {<br/>}<br/><br/>false:<br/>if (foo()) {<br/>} else {<br/>}</pre></html>"
+EditorType=boolean
+TrueFalse="    BeforeElse: true|    BeforeElse: false"
+Value=0
+ValueDefault=0
+
+[ - IndentBraces]
+Category=2
+Description="<html>Indent the wrapped braces themselves.</html>"
+EditorType=boolean
+TrueFalse="    IndentBraces: true|    IndentBraces: false"
+Value=0
+ValueDefault=0
+
+[ - SplitEmptyFunction]
+Category=2
+Description="<html>If <code>false</code>, empty function body can be put on a single line. This option is used only if the opening brace of the function has already been wrapped, i.e. the <code>AfterFunction</code> brace wrapping mode is set, and the function could/should not be put on a single line (as per <code>AllowShortFunctionsOnASingleLine</code> and constructor formatting options).<pre>int f()   vs.   inf f()<br/>{}              {<br/>                }</pre></html>"
+EditorType=boolean
+TrueFalse="    SplitEmptyFunction: true|    SplitEmptyFunction: false"
+Value=0
+ValueDefault=0
+
+[ - SplitEmptyRecord]
+Category=2
+Description="<html>If <code>false</code>, empty record (e.g. <code>class</code>, <code>struct</code> or <code>union</code>) body can be put on a single line. This option is used only if the opening brace of the record has already been wrapped, i.e. the <code>AfterClass</code> (for classes) brace wrapping mode is set.<pre>class Foo   vs.  class Foo<br/>{}               {<br/>                 }</pre></html>"
+EditorType=boolean
+TrueFalse="    SplitEmptyRecord: true|    SplitEmptyRecord: false"
+Value=0
+ValueDefault=0
+
+[ - SplitEmptyNamespace]
+Category=2
+Description="<html>If <code>false</code>, empty namespace body can be put on a single line. This option is used only if the opening brace of the namespace has already been wrapped, i.e. the <code>AfterNamespace</code> brace wrapping mode is set.<pre>namespace Foo   vs.  namespace Foo<br/>{}                   {<br/>                     }</pre></html>"
+EditorType=boolean
+TrueFalse="    SplitEmptyNamespace: true|    SplitEmptyNamespace: false"
+Value=0
+ValueDefault=0
+
+[BreakAfterJavaFieldAnnotations]
+Category=1
+Description="<html>Break after each annotation on a field in Java files.<pre>true:                                  false:<br/>@Partial                       vs.     @Partial @Mock DataLoad loader;<br/>@Mock<br/>DataLoad loader;</pre></html>"
+EditorType=boolean
+TrueFalse="BreakAfterJavaFieldAnnotations: true|BreakAfterJavaFieldAnnotations: false"
+Value=0
+ValueDefault=0
+
+[BreakBeforeBinaryOperators]
+Category=1
+Description="<html>(BreakBeforeBinaryOperators) The way to wrap binary operators.</html>"
+EditorType=multiple
+Enabled=false
+Choices="BreakBeforeBinaryOperators: None|BreakBeforeBinaryOperators: NonAssignment|BreakBeforeBinaryOperators: All"
+ChoicesReadable="(None) Break after operators.|(NonAssignment) Break before operators that aren’t assignments.|(All) Break before operators."
+ValueDefault=0
+
+[BreakBeforeTernaryOperators]
+Category=1
+Description="<html>Ternary operators will be placed after line breaks.<pre>true:<br/>veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongDescription<br/>    ? firstValue<br/>    : SecondValueVeryVeryVeryVeryLong;<br/><br/>false:<br/>veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongDescription ?<br/>    firstValue :<br/>    SecondValueVeryVeryVeryVeryLong;</pre></html>"
+EditorType=boolean
+TrueFalse="BreakBeforeTernaryOperators: true|BreakBeforeTernaryOperators: false"
+Value=0
+ValueDefault=0
+
+[BreakConstructorInitializers]
+Category=1
+Description="<html>(BreakConstructorInitializers) The constructor initializers style to use.</html>"
+EditorType=multiple
+Enabled=false
+Choices="BreakConstructorInitializers: BeforeColon|BreakConstructorInitializers: BeforeComma|BreakConstructorInitializers: AfterColon"
+ChoicesReadable="(BeforeColon) Break constructor initializers before the colon and after the commas.|(BeforeComma) Break constructor initializers before the colon and commas, and align the commas with the colon.|(AfterColon) Break constructor initializers after the colon and commas."
+ValueDefault=0
+
+[BreakInheritanceList]
+Category=1
+Description="<html>The inheritance list style to use.</html>"
+EditorType=multiple
+Enabled=false
+Choices="BreakInheritanceList: BeforeColon|BreakInheritanceList: BeforeComma|BreakInheritanceList: AfterColon"
+ChoicesReadable="(BeforeColon) Break inheritance list before the colon and after the commas.|(BeforeComma) Break inheritance list before the colon and commas, and align the commas with the colon.|(AfterColon) Break inheritance list after the colon and commas."
+ValueDefault=0
+
+[BreakStringLiterals]
+Category=1
+Description="<html>Allow breaking string literals when formatting.</html>"
+EditorType=boolean
+TrueFalse="BreakStringLiterals: true|BreakStringLiterals: false"
+Value=1
+ValueDefault=1
+
+[ColumnLimit]
+Category=1
+Description="<html>The column limit.<p>A column limit of <code>0</code> means that there is no column limit. In this case, clang-format will respect the input’s line breaking decisions within statements unless they contradict other rules.</html>"
+EditorType=numeric
+Enabled=false
+CallName="ColumnLimit: "
+MaxVal=2000
+MinVal=0
+Value=80
+ValueDefault=80
+
+[CommentPragmas]
+Category=1
+Description="<html>A regular expression that describes comments with special meaning, which should not be split into lines or otherwise changed.<pre>// CommentPragmas: '^ FOOBAR pragma:'<br/>// Will leave the following line unaffected<br/>#include &lt;vector&gt; // FOOBAR pragma: keep</pre></html>"
+EditorType=string
+CallName="CommentPragmas: "
+Enabled=false
+Value="''"
+ValueDefault="''"
+
+[CompactNamespaces]
+Category=1
+Description="<html>If <code>true</code>, consecutive namespace declarations will be on the same line. If <code>false</code>, each namespace is declared on a new line.<pre>true:<br/>namespace Foo { namespace Bar {<br/>}}<br/><br/>false:<br/>namespace Foo {<br/>namespace Bar {<br/>}<br/>}</pre><p>If it does not fit on a single line, the overflowing namespaces get wrapped:</p><pre>namespace Foo { namespace Bar {<br/>namespace Extra {<br/>}}}</html>"
+EditorType=boolean
+TrueFalse="CompactNamespaces: true|CompactNamespaces: false"
+Value=0
+ValueDefault=0
+
+[ConstructorInitializerAllOnOneLineOrOnePerLine]
+Category=1
+Description="<html>If the constructor initializers don’t fit on a line, put each initializer on its own line.<pre>true:<br/>SomeClass::Constructor()<br/>    : aaaaaaaa(aaaaaaaa), aaaaaaaa(aaaaaaaa), aaaaaaaa(aaaaaaaaaaaaaaaaaaaaaaaaa) {<br/>  return 0;<br/>}<br/><br/>false:<br/>SomeClass::Constructor()<br/>    : aaaaaaaa(aaaaaaaa), aaaaaaaa(aaaaaaaa),<br/>      aaaaaaaa(aaaaaaaaaaaaaaaaaaaaaaaaa) {<br/>  return 0;<br/>}</pre></html>"
+EditorType=boolean
+TrueFalse="ConstructorInitializerAllOnOneLineOrOnePerLine: true|ConstructorInitializerAllOnOneLineOrOnePerLine: false"
+Value=0
+ValueDefault=0
+
+[ConstructorInitializerIndentWidth]
+Category=3
+Description="<html>The number of characters to use for indentation of constructor initializer lists.</html>"
+EditorType=numeric
+Enabled=false
+CallName="ConstructorInitializerIndentWidth: "
+MaxVal=2000
+MinVal=0
+Value=4
+ValueDefault=4
+
+[ContinuationIndentWidth]
+Category=3
+Description="<html>Indent width for line continuations.<pre>ContinuationIndentWidth: 2<br/><br/>int i =         //  VeryVeryVeryVeryVeryLongComment<br/>  longFunction( // Again a long comment<br/>    arg);</pre></html>"
+EditorType=numeric
+Enabled=false
+CallName="ConstructorInitializerIndentWidth: "
+MaxVal=2000
+MinVal=0
+Value=4
+ValueDefault=4
+
+[Cpp11BracedListStyle]
+Category=5
+Description="<html>If <code>true</code>, format braced lists as best suited for C++11 braced lists.<p>Important differences:<ul><li>No spaces inside the braced list.</li><li>No line break before the closing brace.</li><li>Indentation with the continuation indent, not with the block indent.</li></ul><p>Fundamentally, C++11 braced lists are formatted exactly like function calls would be formatted in their place. If the braced list follows a name (e.g. a type or variable name), clang-format formats as if the <code>{}</code> were the parentheses of a function call with that name. If there is no name, a zero-length name is assumed.<pre>true:                                  false:<br/>vector&lt;int&gt; x{1, 2, 3, 4};     vs.     vector&lt;int&gt; x{ 1, 2, 3, 4 };<br/>vector&lt;T&gt; x{{}, {}, {}, {}};           vector&lt;T&gt; x{ {}, {}, {}, {} };<br/>f(MyMap[{composite, key}]);            f(MyMap[{ composite, key }]);<br/>new int[3]{1, 2, 3};                   new int[3]{ 1, 2, 3 };</pre></html>"
+EditorType=boolean
+TrueFalse="Cpp11BracedListStyle: true|Cpp11BracedListStyle: false"
+Value=1
+ValueDefault=1
+
+[DerivePointerAlignment]
+Category=5
+Description="<html>If <code>true</code>, analyze the formatted file for the most common alignment of <code>&</code> and <code>*</code>. Pointer and reference alignment styles are going to be updated according to the preferences found in the file. <code>PointerAlignment</code> is then used only as fallback.</html>"
+EditorType=boolean
+TrueFalse="DerivePointerAlignment: true|DerivePointerAlignment: false"
+Value=0
+ValueDefault=0
+
+[DisableFormat]
+Category=0
+Description="<html>Disables formatting completely.</html>"
+EditorType=boolean
+TrueFalse="DisableFormat: true|DisableFormat: false"
+Value=0
+ValueDefault=0
+
+[FixNamespaceComments]
+Category=7
+Description="<html>If <code>true</code>, clang-format adds missing namespace end comments and fixes invalid existing ones.<pre>true:                                  false:<br/>namespace a {                  vs.     namespace a {<br/>foo();                                 foo();<br/>} // namespace a;                      }</pre></html>"
+EditorType=boolean
+TrueFalse="FixNamespaceComments: true|FixNamespaceComments: false"
+Value=1
+ValueDefault=1
+
+[ForEachMacros]
+Category=7
+Description="<html>A vector of macros that should be interpreted as foreach loops instead of as function calls.<p>These are expected to be macros of the form:<pre>FOREACH(<variable-declaration>, ...)<br/>  <loop-body></pre><p>In the <code>.clang-format</code> configuration file, this can be configured like:<pre>ForEachMacros: ['RANGES_FOR', 'FOREACH']</pre><p>For example: <code>BOOST_FOREACH</code>.</html>"
+EditorType=string
+CallName="ForEachMacros: "
+Enabled=false
+Value="[]"
+ValueDefault="[]"
+
+[IncludeBlocks]
+Category=7
+Description="<html>Dependent on the value, multiple <code>#include</code> blocks can be sorted as one and divided based on category.</html>"
+EditorType=multiple
+Enabled=false
+Choices="IncludeBlocks: Preserve|IncludeBlocks: Merge|IncludeBlocks: Regroup"
+ChoicesReadable="(Preserve) Sort each #include block separately.|(Merge) Merge multiple #include blocks together and sort as one.|(Regroup) Merge multiple #include blocks together and sort as one. Then split into groups based on category priority. See IncludeCategories."
+ValueDefault=0
+
+[IncludeIsMainRegex]
+Category=7
+Description="<html>Specify a regular expression of suffixes that are allowed in the file-to-main-include mapping.<p>When guessing whether a <code>#include</code> is the “main” include, use this regex of allowed suffixes to the header stem. A partial match is done, so that: - “” means “arbitrary suffix” - “<code>$</code>” means “no suffix”.<p>For example, if configured to “<code>(_test)?$</code>”, then a header <code>a.h</code> would be seen as the “main” include in both <code>a.cc</code> and <code>a_test.cc</code>.</html>"
+EditorType=string
+CallName="IncludeIsMainRegex: "
+Enabled=false
+Value="''"
+ValueDefault="''"
+
+[IndentCaseLabels]
+Category=3
+Description="<html>Indent <code>case</code> labels one level from the <code>switch</code> statement.<p>When <code>false</code>, use the same indentation level as for the <code>switch</code> statement. Switch statement body is always indented one level more than <code>case</code> labels.<pre>false:                                 true:<br/>switch (fool) {                vs.     switch (fool) {<br/>case 1:                                  case 1:<br/>  bar();                                   bar();<br/>  break;                                   break;<br/>default:                                 default:<br/>  plop();                                  plop();<br/>}                                      }</pre></html>"
+EditorType=boolean
+TrueFalse="IndentCaseLabels: true|IndentCaseLabels: false"
+Value=0
+ValueDefault=0
+
+[IndentPPDirectives]
+Category=3
+Description="<html>The preprocessor directive indenting style to use.</html>"
+EditorType=boolean
+TrueFalse="IndentPPDirectives: AfterHash|IndentPPDirectives: None"
+Value=0
+ValueDefault=0
+
+[IndentWidth]
+Category=3
+Description="<html>The number of columns to use for indentation.<pre>IndentWidth: 3<br/><br/>void f() {<br/>   someFunction();<br/>   if (true, false) {<br/>      f();<br/>   }<br/>}</pre></html>"
+EditorType=numeric
+Enabled=false
+CallName="IndentWidth: "
+MaxVal=1000
+MinVal=0
+Value=2
+ValueDefault=2
+
+[IndentWrappedFunctionNames]
+Category=3
+Description="<html>Indent if a function definition or declaration is wrapped after the type.<pre>true:<br/>LoooooooooooooooooooooooooooooooooooooooongReturnType<br/>    LoooooooooooooooooooooooooooooooongFunctionDeclaration();<br/><br/>false:<br/>LoooooooooooooooooooooooooooooooooooooooongReturnType<br/>LoooooooooooooooooooooooooooooooongFunctionDeclaration();</pre></html>"
+EditorType=boolean
+TrueFalse="IndentWrappedFunctionNames: true|IndentWrappedFunctionNames: false"
+Value=0
+ValueDefault=0
+
+[JavaScriptQuotes]
+Category=7
+Description="<html>The quote style to use for JavaScript strings.</html>"
+EditorType=multiple
+Enabled=false
+Choices="JavaScriptQuotes: Leave|JavaScriptQuotes: Single|JavaScriptQuotes: Double"
+ChoicesReadable="(Leave) Leave string quotes as they are.|(Single) Always use single quotes.|(Double) Always use double quotes."
+ValueDefault=0
+
+[JavaScriptWrapImports]
+Category=1
+Description="<html>Whether to wrap JavaScript <code>import</code>/<code>export</code> statements.<pre>true:<br/>import {<br/>    VeryLongImportsAreAnnoying,<br/>    VeryLongImportsAreAnnoying,<br/>    VeryLongImportsAreAnnoying,<br/>} from 'some/module.js'<br/><br/>false:<br/>import {VeryLongImportsAreAnnoying, VeryLongImportsAreAnnoying, VeryLongImportsAreAnnoying,} from &quot;some/module.js&quot;</pre></html>"
+EditorType=boolean
+TrueFalse="JavaScriptWrapImports: true|JavaScriptWrapImports: false"
+Value=0
+ValueDefault=0
+
+[KeepEmptyLinesAtTheStartOfBlocks]
+Category=6
+Description="<html>If <code>true</code>, the empty line at the start of blocks is kept.<pre>true:                                  false:<br/>if (foo) {                     vs.     if (foo) {<br/>                                         bar();<br/>  bar();                               }<br/>}</pre></html>"
+EditorType=boolean
+TrueFalse="KeepEmptyLinesAtTheStartOfBlocks: true|KeepEmptyLinesAtTheStartOfBlocks: false"
+Value=0
+ValueDefault=0
+
+[MacroBlockBegin]
+Category=3
+Description="<html>A regular expression matching macros that start a block.</html>"
+EditorType=string
+CallName="MacroBlockBegin: "
+Enabled=false
+Value="''"
+ValueDefault="''"
+
+[MacroBlockEnd]
+Category=3
+Description="<html>A regular expression matching macros that end a block.</html>"
+EditorType=string
+CallName="MacroBlockEnd: "
+Enabled=false
+Value="''"
+ValueDefault="''"
+
+[MaxEmptyLinesToKeep]
+Category=6
+Description="<html>The maximum number of consecutive empty lines to keep.</pre>MaxEmptyLinesToKeep: 1         vs.     MaxEmptyLinesToKeep: 0<br/>int f() {                              int f() {<br/>  int = 1;                                 int i = 1;<br/>                                           i = foo();<br/>  i = foo();                               return i;<br/>                                       }<br/>  return i;<br/>}</pre></html>"
+EditorType=numeric
+Enabled=false
+CallName="MaxEmptyLinesToKeep: "
+MaxVal=1000
+MinVal=0
+Value=1
+ValueDefault=1
+
+[NamespaceIndentation]
+Category=3
+Description="<html>The indentation used for namespaces.</html>"
+EditorType=multiple
+Enabled=false
+Choices="NamespaceIndentation: None|NamespaceIndentation: Inner|NamespaceIndentation: All"
+ChoicesReadable="(None) Don’t indent in namespaces.|(Inner) Indent only in inner namespaces (nested in other namespaces).|(All) Indent in all namespaces."
+ValueDefault=0
+
+[ObjCBinPackProtocolList]
+Category=1
+Description="<html>Controls bin-packing Objective-C protocol conformance list items into as few lines as possible when they go over <code>ColumnLimit</code>.<p>If <code>Auto</code> (the default), delegates to the value in <code>BinPackParameters</code>. If that is <code>true</code>, bin-packs Objective-C protocol conformance list items into as few lines as possible whenever they go over <code>ColumnLimit</code>.<p>If <code>Always</code>, always bin-packs Objective-C protocol conformance list items into as few lines as possible whenever they go over <code>ColumnLimit</code>.<p>If <code>Never</code>, lays out Objective-C protocol conformance list items onto individual lines whenever they go over <code>ColumnLimit</code>.<pre>Always (or Auto, if BinPackParameters=true):<br/>@interface ccccccccccccc () &lt;<br/>    ccccccccccccc, ccccccccccccc,<br/>    ccccccccccccc, ccccccccccccc> {<br/>}<br/><br/>Never (or Auto, if BinPackParameters=false):<br/>@interface ddddddddddddd () &lt;<br/>    ddddddddddddd,<br/>    ddddddddddddd,<br/>    ddddddddddddd,<br/>    ddddddddddddd> {<br/>}</pre></html>"
+EditorType=multiple
+Enabled=false
+Choices="ObjCBinPackProtocolList: Auto|ObjCBinPackProtocolList: Always|ObjCBinPackProtocolList: Never"
+ChoicesReadable="(Auto) Automatically determine parameter bin-packing behavior.|(Always) Always bin-pack parameters.|(Never) Never bin-pack parameters."
+ValueDefault=0
+
+[ObjCBlockIndentWidth]
+Category=3
+Description="<html>The number of characters to use for indentation of ObjC blocks.<pre>ObjCBlockIndentWidth: 4<br/><br/>[operation setCompletionBlock:^{<br/>    [self onOperationDone];<br/>}];</pre></html>"
+EditorType=numeric
+Enabled=false
+CallName="ObjCBlockIndentWidth: "
+MaxVal=1000
+MinVal=0
+Value=2
+ValueDefault=2
+
+[ObjCSpaceAfterProperty]
+Category=5
+Description="<html>Add a space after <code>@property</code> in Objective-C, i.e. use <code>@property (readonly)</code> instead of <code>@property(readonly)</code>.</html>"
+EditorType=boolean
+TrueFalse="ObjCSpaceAfterProperty: true|ObjCSpaceAfterProperty: false"
+Value=0
+ValueDefault=0
+
+[ObjCSpaceBeforeProtocolList]
+Category=5
+Description="<html>Add a space in front of an Objective-C protocol list, i.e. use <code>Foo &lt;Protocol&gt;</code> instead of <code>Foo&lt;Protocol&gt;</code>.</html>"
+EditorType=boolean
+TrueFalse="ObjCSpaceBeforeProtocolList: true|ObjCSpaceBeforeProtocolList: false"
+Value=0
+ValueDefault=0
+
+[PenaltyBreakAssignment]
+Category=1
+Description="<html>The penalty for breaking around an assignment operator.</html>"
+EditorType=numeric
+Enabled=false
+CallName="PenaltyBreakAssignment: "
+MaxVal=10000000
+MinVal=0
+Value=0
+ValueDefault=0
+
+[PenaltyBreakBeforeFirstCallParameter]
+Category=1
+Description="<html>The penalty for breaking a function call after <code>call(</code>.</html>"
+EditorType=numeric
+Enabled=false
+CallName="PenaltyBreakBeforeFirstCallParameter: "
+MaxVal=10000000
+MinVal=0
+Value=0
+ValueDefault=0
+
+[PenaltyBreakComment]
+Category=1
+Description="<html>The penalty for each line break introduced inside a comment.</html>"
+EditorType=numeric
+Enabled=false
+CallName="PenaltyBreakComment: "
+MaxVal=10000000
+MinVal=0
+Value=0
+ValueDefault=0
+
+[PenaltyBreakFirstLessLess]
+Category=1
+Description="<html>The penalty for breaking before the first <code>&lt;&lt;</code>.</html>"
+EditorType=numeric
+Enabled=false
+CallName="PenaltyBreakFirstLessLess: "
+MaxVal=10000000
+MinVal=0
+Value=0
+ValueDefault=0
+
+[PenaltyBreakString]
+Category=1
+Description="<html>The penalty for each line break introduced inside a string literal.</html>"
+EditorType=numeric
+Enabled=false
+CallName="PenaltyBreakString: "
+MaxVal=10000000
+MinVal=0
+Value=0
+ValueDefault=0
+
+[PenaltyBreakTemplateDeclaration]
+Category=1
+Description="<html>The penalty for breaking after template declaration.</html>"
+EditorType=numeric
+Enabled=false
+CallName="PenaltyBreakTemplateDeclaration: "
+MaxVal=10000000
+MinVal=0
+Value=0
+ValueDefault=0
+
+[PenaltyExcessCharacter]
+Category=1
+Description="<html>The penalty for each character outside of the column limit.</html>"
+EditorType=numeric
+Enabled=false
+CallName="PenaltyExcessCharacter: "
+MaxVal=10000000
+MinVal=0
+Value=0
+ValueDefault=0
+
+[PenaltyReturnTypeOnItsOwnLine]
+Category=1
+Description="<html>Penalty for putting the return type of a function onto its own line.</html>"
+EditorType=numeric
+Enabled=false
+CallName="PenaltyReturnTypeOnItsOwnLine: "
+MaxVal=10000000
+MinVal=0
+Value=0
+ValueDefault=0
+
+[PointerAlignment]
+Category=5
+Description="<html>Pointer and reference alignment style.</html>"
+EditorType=multiple
+Enabled=false
+Choices="PointerAlignment: Left|PointerAlignment: Middle|PointerAlignment: Right"
+ChoicesReadable="(Left) Align pointer to the left.|(Middle) Align pointer in the middle.|(Right) Align pointer to the right."
+ValueDefault=2
+
+[ReflowComments]
+Category=1
+Description="<html>If <code>true</code>, clang-format will attempt to re-flow comments.<pre>false:<br/>// veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongComment with plenty of information<br/>/* second veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongComment with plenty of information */<br/><br/>true:<br/>// veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongComment with plenty of<br/>// information<br/>/* second veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongComment with plenty of<br/> * information */</pre></html>"
+EditorType=boolean
+TrueFalse="ReflowComments: true|ReflowComments: false"
+Value=1
+ValueDefault=1
+
+[SortIncludes]
+Category=7
+Description="<html>If <code>true</code>, clang-format will sort <code>#include</code>s.<pre>false:                                 true:<br/>#include &quot;b.h&quot;                 vs.     #include &quot;a.h&quot;<br/>#include &quot;a.h&quot;                         #include &quot;b.h&quot;</pre></html>"
+EditorType=boolean
+TrueFalse="SortIncludes: true|SortIncludes: false"
+Value=1
+ValueDefault=1
+
+[SortUsingDeclarations]
+Category=7
+Descriptions="<html>If <code>true</code>, clang-format will sort <code>using</code> declarations.<p>The order of <code>using</code> declarations is defined as follows: Split the strings by “::” and discard any initial empty strings. The last element of each list is a non-namespace name; all others are namespace names. Sort the lists of names lexicographically, where the sort order of individual names is that all non-namespace names come before all namespace names, and within those groups, names are in case-insensitive lexicographic order.<pre>false:                                 true:<br/>using std::cout;               vs.     using std::cin;<br/>using std::cin;                        using std::cout;</pre></html>"
+EditorType=boolean
+TrueFalse="SortUsingDeclarations: true|SortUsingDeclarations: false"
+Value=1
+ValueDefault=1
+
+[SpaceAfterCStyleCast]
+Category=5
+Description="<html>If <code>true</code>, a space is inserted after C style casts.<pre>true:                                  false:<br/>(int) i;                       vs.     (int)i;</pre></html>"
+EditorType=boolean
+TrueFalse="SpaceAfterCStyleCast: true|SpaceAfterCStyleCast: false"
+Value=0
+ValueDefault=0
+
+[SpaceAfterTemplateKeyword]
+Category=5
+Description="<html>If <code>true</code>, a space will be inserted after the ‘<code>template</code>’ keyword.<pre>true:                                  false:<br/>template &lt;int&gt; void foo();     vs.     template&lt;int&gt; void foo();</pre></html>"
+EditorType=boolean
+TrueFalse="SpaceAfterTemplateKeyword: true|SpaceAfterTemplateKeyword: false"
+Value=1
+ValueDefault=1
+
+[SpaceBeforeAssignmentOperators]
+Category=5
+Description="<html>If <code>false</code>, spaces will be removed before assignment operators.<pre>true:                                  false:<br/>int a = 5;                     vs.     int a= 5;<br/>a += 42                                a+= 42;</pre></html>"
+EditorType=boolean
+TrueFalse="SpaceBeforeAssignmentOperators: true|SpaceBeforeAssignmentOperators: false"
+Value=1
+ValueDefault=1
+
+[SpaceBeforeCpp11BracedList]
+Category=5
+Description="<html>If <code>true</code>, a space will be inserted before a C++11 braced list used to initialize an object (after the preceding identifier or type).<pre>true:                                  false:<br/>Foo foo { bar };               vs.     Foo foo{ bar };<br/>Foo {};                                Foo{};<br/>vector<int> { 1, 2, 3 };               vector<int>{ 1, 2, 3 };<br/>new int[3] { 1, 2, 3 };                new int[3]{ 1, 2, 3 };</pre></html>"
+EditorType=boolean
+TrueFalse="SpaceBeforeCpp11BracedList: true|SpaceBeforeCpp11BracedList: false"
+Value=1
+ValueDefault=1
+
+[SpaceBeforeCtorInitializerColon]
+Category=5
+Description="<html>If <code>false</code>, spaces will be removed before constructor initializer colon.<pre>true:                                  false:<br/>Foo::Foo() : a(a) {}                   Foo::Foo(): a(a) {}</pre></html>"
+EditorType=boolean
+TrueFalse="SpaceBeforeCtorInitializerColon: true|SpaceBeforeCtorInitializerColon: false"
+Value=1
+ValueDefault=1
+
+[SpaceBeforeInheritanceColon]
+Category=5
+Description="<html>If <code>false</code>, spaces will be removed before inheritance colon.<pre>true:                                  false:<br/>class Foo : Bar {}             vs.     class Foo: Bar {}</pre></html>"
+EditorType=boolean
+TrueFalse="SpaceBeforeInheritanceColon: true|SpaceBeforeInheritanceColon: false"
+Value=1
+ValueDefault=1
+
+[SpaceBeforeParens]
+Category=5
+Description="<html>Defines in which cases to put a space before opening parentheses.</html>"
+EditorType=multiple
+Enabled=false
+Choices="SpaceBeforeParens: Never|SpaceBeforeParens: ControlStatements|SpaceBeforeParens: Always"
+ChoicesReadable="(Never) Never put a space before opening parentheses.|(ControlStatements) Put a space before opening parentheses only after control statement keywords (for/if/while...).|(Always) Always put a space before opening parentheses, except when it’s prohibited by the syntax rules (in function-like macro definitions) or when determined by other style rules (after unary operators, opening parentheses, etc.)"
+ValueDefault=1
+
+[SpaceBeforeRangeBasedForLoopColon]
+Category=5
+Description="<html>If <code>false</code>, spaces will be removed before range-based <code>for</code> loop colon.<pre>true:                                  false:<br/>for (auto v : values) {}       vs.     for(auto v: values) {}</pre></html>"
+EditorType=boolean
+TrueFalse="SpaceBeforeRangeBasedForLoopColon: true|SpaceBeforeRangeBasedForLoopColon: false"
+Value=1
+ValueDefault=1
+
+[SpaceInEmptyParentheses]
+Category=5
+Description="<html>If <code>true</code>, spaces may be inserted into <code>()</code>.<pre>true:                                false:<br/>void f( ) {                    vs.   void f() {<br/>  int x[] = {foo( ), bar( )};          int x[] = {foo(), bar()};<br/>  if (true) {                          if (true) {<br/>    f( );                                f();<br/>  }                                    }<br/>}                                    }</pre></html>"
+EditorType=boolean
+TrueFalse="SpaceInEmptyParentheses: true|SpaceInEmptyParentheses: false"
+Value=0
+ValueDefault=0
+
+[SpaceBeforeTrailingComments]
+Category=5
+Description="<html>The number of spaces before trailing line comments (<code>//</code> - comments).<p>This does not affect trailing block comments (<code>/*</code> - comments) as those commonly have different usage patterns and a number of special cases.<pre>SpacesBeforeTrailingComments: 3<br/>void f() {<br/>  if (true) {   // foo1<br/>    f();        // bar<br/>  }             // foo<br/>}</pre></html>"
+EditorType=numeric
+Enabled=false
+CallName="SpaceBeforeTrailingComments: "
+MaxVal=100
+MinVal=0
+Value=1
+ValueDefault=1
+
+[SpacesInAngles]
+Category=5
+Description="<html>If <code>true</code>, spaces will be inserted after &lt; and before &gt; in template argument lists.<pre>true:                                  false:<br/>static_cast&lt; int &gt;(arg);       vs.     static_cast&lt;int&gt;(arg);<br/>std::function&lt; void(int) &gt; fct;        std::function&lt;void(int)&gt; fct;</pre></html>"
+EditorType=boolean
+TrueFalse="SpacesInAngles: true|SpacesInAngles: false"
+Value=0
+ValueDefault=0
+
+[SpacesInCStyleCastParentheses]
+Category=5
+Description="<html>If <code>true</code>, spaces may be inserted into C style casts.<pre>true:                                  false:<br/>x = ( int32 )y                 vs.     x = (int32)y</pre></html>"
+EditorType=boolean
+TrueFalse="SpacesInCStyleCastParentheses: true|SpacesInCStyleCastParentheses: false"
+Value=0
+ValueDefault=0
+
+[SpacesInContainerLiterals]
+Category=5
+Description="<html>If <code>true</code>, spaces are inserted inside container literals (e.g. ObjC and Javascript array and <code>dict</code> literals).<pre>true:                                  false:<br/>var arr = [ 1, 2, 3 ];         vs.     var arr = [1, 2, 3];<br/>f({a : 1, b : 2, c : 3});              f({a: 1, b: 2, c: 3});</pre></html>"
+EditorType=boolean
+TrueFalse="SpacesInContainerLiterals: true|SpacesInContainerLiterals: false"
+Value=0
+ValueDefault=0
+
+[SpacesInParentheses]
+Category=5
+Description="<html>If true, spaces will be inserted after ( and before ).<pre>true:                                  false:<br/>t f( Deleted & ) & = delete;   vs.     t f(Deleted &) & = delete;</pre></html>"
+EditorType=boolean
+TrueFalse="SpacesInParentheses: true|SpacesInParentheses: false"
+Value=0
+ValueDefault=0
+
+[SpacesInSquareBrackets]
+Category=5
+Description="<html>If <code>true</code>, spaces will be inserted after <code>[</code> and before <code>]</code>. Lambdas or unspecified size array declarations will not be affected.<pre>true:                                  false:<br/>int a[ 5 ];                    vs.     int a[5];<br/>std::unique_ptr&lt;int[]&gt; foo() {} // Won't be affected</pre></html>"
+EditorType=boolean
+TrueFalse="SpacesInSquareBrackets: true|SpacesInSquareBrackets: false"
+Value=0
+ValueDefault=0
+
+[Standard]
+Category=0
+Description="<html>Format compatible with this standard, e.g. use <code>A&lt;A&lt;int&gt; &gt;</code> instead of <code>A&lt;A&lt;int&gt;&gt;</code> for </code>Cpp03</code>.</html>"
+EditorType=multiple
+Enabled=false
+Choices="Standard: Cpp03|Standard: Cpp11|Standard: Auto"
+ChoicesReadable="(Cpp03) Use C++03-compatible syntax.|(Cpp11) Use features of C++11, C++14 and C++1z (e.g. A<A<int>> instead of A<A<int> >).|(Auto) Automatic detection based on the input."
+ValueDefault=2
+
+[TabWidth]
+Category=3
+Description="<html>The number of columns used for tab stops.</html>"
+EditorType=numeric
+Enabled=false
+CallName="TabWidth: "
+MaxVal=100
+MinVal=0
+Value=8
+ValueDefault=8
+
+[UseTab]
+Category=3
+Description="<html>The way to use tab characters in the resulting file.</html>"
+EditorType=multiple
+Enabled=false
+Choices="UseTab: Never|UseTab: ForIndentation|UseTab: ForContinuationAndIndentation|UseTab: Always"
+ChoicesReadable="(Never) Never use tab.|(ForIndentation) Use tabs only for indentation.|(ForContinuationAndIndentation) Use tabs only for line continuation and indentation.|(Always) Use tabs whenever we need to fill whitespace that spans at least from one tab stop to the next one."
+ValueDefault=0

--- a/readme.html
+++ b/readme.html
@@ -63,6 +63,7 @@ a.external
             <ul>
                 <li><a class="external" href="http://astyle.sourceforge.net/">Artistic Styler</a></li>
                 <li><a class="external" href="http://invisible-island.net/bcpp/">BCPP</a></li>
+                <li><a class="external" href="https://clang.llvm.org/docs/ClangFormat.html">ClangFormat</a></li>
                 <li><a class="external" href="http://www.siber.com/sct/tools/cbl-beau.html">Cobol Beautify</a></li>
                 <li><a class="external" href="http://csstidy.sourceforge.net/">CSSTidy</a></li>
                 <li><a class="external" href="ftp://ftp.ifremer.fr/ifremer/ditigo/fortran90/">Fortran 90 PPR</a></li>
@@ -187,7 +188,7 @@ a.external
             </ol>
         </ol>
         <b>Indenter binary packages</b> can be downloaded from the project at SourceForge
-        <a class="external" href="http://sourceforge.net/project/showfiles.php?group_id=167482&package_id=293094">here</a>.
+        <a class="external" href="http://sourceforge.net/project/showfiles.php?group_id=167482&package_id=293094">here</a>. <b>ClangFormat</b> is not part of them (yet), and you can download it separately at <a class="external" href="http://llvm.org/builds/">the LLVM Builds page</a>. (Rename it to <code>clang-format.exe</code> after downloading if needed.)
         <p>Beneath the possibility to build UiGUI using qmake, also project files for Visual Studio 2005
         and XCode are included.</p>
     </p>


### PR DESCRIPTION
Add an indenter configuration file for [ClangFormat v7.0.0](http://releases.llvm.org/7.0.0/tools/clang/docs/ClangFormat.html). It can generate all the documented `.clang-format` options, except the following:

 - `ExperimentalAutoDetectBinPacking`, because it is discouraged from use in config files.

 - `AlwaysBreakAfterDefinitionReturnType`, as it is now deprecated.

 - `IncludeCategories` and `RawStringFormats`, because their option values are highly structured YAML and beyond the capabilities of UniversalIndentGUI.

Also enlist ClangFormat in the list of supported indenters in the text, HTML and Markdown README files (but not in the binary PDF file) and in the release packaging scripts.